### PR TITLE
Fixes for aarch64 targets

### DIFF
--- a/Sources/nuklear/module.modulemap
+++ b/Sources/nuklear/module.modulemap
@@ -1,5 +1,4 @@
 module nuklear {
     header "nuklear.h"
     export *
-    link "nuklear"
 }

--- a/Sources/nuklear/nuklear.h
+++ b/Sources/nuklear/nuklear.h
@@ -370,7 +370,7 @@ extern "C" {
     #elif (defined(_WIN32) || defined(WIN32)) && defined(_MSC_VER)
       #define NK_SIZE_TYPE unsigned __int32
     #elif defined(__GNUC__) || defined(__clang__)
-      #if defined(__x86_64__) || defined(__ppc64__)
+      #if defined(__aarch64__) || defined(__x86_64__) || defined(__ppc64__)
         #define NK_SIZE_TYPE unsigned long
       #else
         #define NK_SIZE_TYPE unsigned int
@@ -385,7 +385,7 @@ extern "C" {
     #elif (defined(_WIN32) || defined(WIN32)) && defined(_MSC_VER)
       #define NK_POINTER_TYPE unsigned __int32
     #elif defined(__GNUC__) || defined(__clang__)
-      #if defined(__x86_64__) || defined(__ppc64__)
+      #if defined(__aarch64__) || defined(__x86_64__) || defined(__ppc64__)
         #define NK_POINTER_TYPE unsigned long
       #else
         #define NK_POINTER_TYPE unsigned int


### PR DESCRIPTION
Two patches:
1. Drop link phase as there is no libnuklear.so/dylib.
2. Add __aarch64__ define check so that typedefs can be appropriately sized.